### PR TITLE
🔧 Add colour for objects without categories

### DIFF
--- a/seatsio-ios/SeatingChartConfig.swift
+++ b/seatsio-ios/SeatingChartConfig.swift
@@ -443,6 +443,9 @@ public class SeatingChartConfig: Encodable {
 
         let jsFunction = """
             (object, dflt, extraConfig) => {
+                if (object == null || object.category == null) {
+                    return "grey";
+                }
                 object.category.color = '\(rgbAvailable)'
                 if (object.category.safeColor) {
                   object.category.safeColor.cachedCss = '\(rgbAvailable)'

--- a/seatsio-ios/SeatingChartConfig.swift
+++ b/seatsio-ios/SeatingChartConfig.swift
@@ -435,16 +435,17 @@ public class SeatingChartConfig: Encodable {
         return self
     }
 
-    public func objectColor(selected: UIColor, available: UIColor, unavailable: UIColor, notForSale: UIColor) -> Self {
+    public func objectColor(selected: UIColor, available: UIColor, unavailable: UIColor, notForSale: UIColor, noCategory: UIColor) -> Self {
         let rgbAvailable = uiColorToJavascriptRGB(available)
         let rgbSelected = uiColorToJavascriptRGB(selected)
         let rgbNotAvailable = uiColorToJavascriptRGB(unavailable)
         let rbgNotForSale = uiColorToJavascriptRGB(notForSale)
+        let rbgNoCategory = uiColorToJavascriptRGB(notForSale)
 
         let jsFunction = """
             (object, dflt, extraConfig) => {
                 if (object == null || object.category == null) {
-                    return "grey";
+                    return '\(rbgNoCategory)';
                 }
                 object.category.color = '\(rgbAvailable)'
                 if (object.category.safeColor) {


### PR DESCRIPTION
Some seats can be configured to have no category attached to them, we need to set a colour for them too
Otherwise, the map won't render